### PR TITLE
feat(api,db,web): server-side search/sort/pagination + DB indexes

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,6 +1,6 @@
 import { getDb } from "../../../db";
 import { advocates } from "../../../db/schema";
-import { and, asc, desc, ilike, or, sql } from "drizzle-orm";
+import { asc, desc, ilike, or, sql } from "drizzle-orm";
 
 export async function GET(req: Request) {
   try {

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,16 +1,69 @@
 import { getDb } from "../../../db";
 import { advocates } from "../../../db/schema";
+import { and, asc, desc, ilike, or, sql } from "drizzle-orm";
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    const { searchParams } = new URL(req.url);
+    const q = (searchParams.get("q") || "").trim();
+    const sort = (searchParams.get("sort") || "lastName") as
+      | "firstName"
+      | "lastName"
+      | "city"
+      | "degree"
+      | "yearsOfExperience";
+    const dir = (searchParams.get("dir") || "asc") as "asc" | "desc";
+    const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
+    const size = Math.max(1, parseInt(searchParams.get("size") || "10", 10));
+
     const db = getDb();
-    const data = await db.select().from(advocates);
-    return Response.json({ data });
+
+    const where = q
+      ? or(
+          ilike(advocates.firstName, `%${q}%`),
+          ilike(advocates.lastName, `%${q}%`),
+          ilike(advocates.city, `%${q}%`),
+          ilike(advocates.degree, `%${q}%`),
+          // cast jsonb specialties to text for a simple contains match
+          sql`(${advocates.specialties})::text ILIKE ${"%" + q + "%"}`,
+          sql`(${advocates.yearsOfExperience})::text ILIKE ${"%" + q + "%"}`
+        )
+      : undefined;
+
+    const orderExpr = (() => {
+      const dirFn = dir === "asc" ? asc : desc;
+      switch (sort) {
+        case "firstName":
+          return dirFn(advocates.firstName);
+        case "lastName":
+          return dirFn(advocates.lastName);
+        case "city":
+          return dirFn(advocates.city);
+        case "degree":
+          return dirFn(advocates.degree);
+        case "yearsOfExperience":
+          return dirFn(advocates.yearsOfExperience);
+      }
+    })();
+
+    const [{ count }] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(advocates)
+      .where(where as any);
+
+    const data = await db
+      .select()
+      .from(advocates)
+      .where(where as any)
+      .orderBy(orderExpr as any)
+      .limit(size)
+      .offset((page - 1) * size);
+
+    return Response.json({ data, page, size, total: Number(count) });
   } catch (err) {
-    // Fallback to static data only in development when DB is not configured
     if (process.env.NODE_ENV !== "production") {
       const { advocateData } = await import("../../../db/seed/advocates");
-      return Response.json({ data: advocateData });
+      return Response.json({ data: advocateData, page: 1, size: advocateData.length, total: advocateData.length });
     }
     return new Response("Database not available", { status: 500 });
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -111,9 +111,8 @@ export default function Home() {
       <br />
       <br />
       {isLoading && (
-        <div className="text-gray-600 flex items-center gap-2">
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
           <Spinner />
-          <span>Loading advocates…</span>
         </div>
       )}
       {error && <div className="text-red-600">{error}</div>}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import AdvocatesTable from "@/components/AdvocatesTable";
 import SortControls from "@/components/SortControls";
 import Pagination from "@/components/Pagination";
 import AdvocateDetailsModal from "@/components/AdvocateDetailsModal";
+import Spinner from "@/components/Spinner";
 
 export default function Home() {
   const [advocates, setAdvocates] = useState<Advocate[]>([]);
@@ -107,7 +108,12 @@ export default function Home() {
       </div>
       <br />
       <br />
-      {isLoading && <div className="text-gray-600">Loading advocates…</div>}
+      {isLoading && (
+        <div className="text-gray-600 flex items-center gap-2">
+          <Spinner />
+          <span>Loading advocates…</span>
+        </div>
+      )}
       {error && <div className="text-red-600">{error}</div>}
       {!isLoading && !error && filteredAdvocates.length === 0 && (
         <div className="text-gray-600">No results. Try adjusting your search.</div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ export default function Home() {
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [selected, setSelected] = useState<Advocate | null>(null);
+  const [hasFetched, setHasFetched] = useState(false);
   // Sync URL state
   useEffect(() => {
     const params = new URLSearchParams();
@@ -53,9 +54,9 @@ export default function Home() {
   }, []);
   useEffect(() => {
     const controller = new AbortController();
+    setIsLoading(true);
     const handler = setTimeout(async () => {
       try {
-        setIsLoading(true);
         const params = new URLSearchParams();
         if (searchTerm) params.set("q", searchTerm);
         if (sortField) params.set("sort", sortField);
@@ -68,6 +69,7 @@ export default function Home() {
         const json: { data: Advocate[]; total: number; page: number; size: number } = await res.json();
         setAdvocates(json.data);
         setFilteredAdvocates(json.data);
+        setHasFetched(true);
       } catch (e) {
         // ignore aborts
       } finally {
@@ -115,7 +117,7 @@ export default function Home() {
         </div>
       )}
       {error && <div className="text-red-600">{error}</div>}
-      {!isLoading && !error && filteredAdvocates.length === 0 && (
+      {!isLoading && !error && hasFetched && filteredAdvocates.length === 0 && (
         <div className="text-gray-600">No results. Try adjusting your search.</div>
       )}
       {!isLoading && !error && filteredAdvocates.length > 0 && (

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import React from "react";
+
+/**
+ * Simple inline spinner
+ */
+const Spinner = () => {
+  return (
+    <div className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
+  );
+};
+
+export default Spinner;
+
+

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,16 +1,26 @@
 import { sql } from "drizzle-orm";
-import { pgTable, integer, text, jsonb, serial, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, integer, text, jsonb, serial, timestamp, index } from "drizzle-orm/pg-core";
 
-const advocates = pgTable("advocates", {
-  id: serial("id").primaryKey(),
-  firstName: text("first_name").notNull(),
-  lastName: text("last_name").notNull(),
-  city: text("city").notNull(),
-  degree: text("degree").notNull(),
-  specialties: jsonb("payload").default([]).notNull(),
-  yearsOfExperience: integer("years_of_experience").notNull(),
-  phoneNumber: text("phone_number").notNull(),
-  createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
-});
+const advocates = pgTable(
+  "advocates",
+  {
+    id: serial("id").primaryKey(),
+    firstName: text("first_name").notNull(),
+    lastName: text("last_name").notNull(),
+    city: text("city").notNull(),
+    degree: text("degree").notNull(),
+    specialties: jsonb("payload").default([]).notNull(),
+    yearsOfExperience: integer("years_of_experience").notNull(),
+    phoneNumber: text("phone_number").notNull(),
+    createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
+  },
+  (t) => ({
+    idxFirstName: index("advocates_first_name_idx").on(t.firstName),
+    idxLastName: index("advocates_last_name_idx").on(t.lastName),
+    idxCity: index("advocates_city_idx").on(t.city),
+    idxDegree: index("advocates_degree_idx").on(t.degree),
+    idxYears: index("advocates_years_idx").on(t.yearsOfExperience),
+  })
+);
 
 export { advocates };


### PR DESCRIPTION
# Summary

API + DB performance: server-side search/sort/pagination with total counts; adds DB indexes; UI fetches paged results; centered spinner overlay during loads; removes empty-state flicker.

# Changes

  - API (`src/app/api/advocates/route.ts`)
    - Supports query params: `q`, `sort` (firstName|lastName|city|degree|yearsOfExperience), `dir` (asc|desc), `page`, `size`.
    - Returns `{ data, total, page, size }`.
  - DB (`src/db/schema.ts`)
    - Adds B-Tree indexes: first_name, last_name, city, degree, years_of_experience.
  - Web (`src/app/page.tsx`)
    - Client fetches paged results via query params; URL stays in sync.
    - Spinner: full-screen centered overlay while fetching.
    - No-results state gated until first fetch completes (no flicker).
  - UI components
    - `Spinner` overlay for loading.

# Rationale

  - Avoids loading entire dataset on the client.
  - Better perceived performance and cleaner UX during fetches.

# How to test

  - Ensure DB is up and schema indexes applied:
    - `DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment npx drizzle-kit push`
  - Seed if needed:
    - `curl -X POST http://localhost:3000/api/seed`
  - In the UI:
    - Search, sort (field + dir), paginate, and change page size; verify stable counts and server-paged results.
    - Observe only a centered spinner during loads; no early “No results” before first fetch resolves.
  - API (manual check):
    - `curl 'http://localhost:3000/api/advocates?q=john&sort=lastName&dir=asc&page=1&size=10'` → should return `{ data, total, page, size }`.

# Notes
  - Order: run drizzle push before seeding to ensure indexes exist.
  - Indexes are created idempotently.